### PR TITLE
Add default make rule to vm makefile

### DIFF
--- a/apps/vm/Makefile
+++ b/apps/vm/Makefile
@@ -25,6 +25,7 @@ ADL ?= vm.camkes
 
 PROJECT_BASE := $(PWD)
 RUMPRUN_BASE_DIR := $(PWD)/libs/rumprun
+all: default
 
 include TimeServer/TimeServer.mk
 include SerialServer/SerialServer.mk


### PR DESCRIPTION
This should prevent a situation where rules defined by the .mk files included below do not override the default camkes rule that should be run