### PR TITLE
Add mutex to Firewall component

### DIFF
--- a/components/Firewall/Firewall.camkes
+++ b/components/Firewall/Firewall.camkes
@@ -17,4 +17,5 @@ component Firewall {
     provides Ethdriver client;
     emits HasData dummy;
     consumes HasData ethdriver_has_data;
+    has mutex ethdriver_buf_crit;
 }


### PR DESCRIPTION
This can be used to restrict access to shared ethdriver_buf dataport
resource between the threads in this component.