### PR TITLE
Add notification pool

### DIFF
--- a/apps/vm/cma34cr_centos.camkes
+++ b/apps/vm/cma34cr_centos.camkes
@@ -134,6 +134,7 @@ component VM {
         firewall.ethdriver_badge = "134217729";
         firewall.ethdriver_mac = [6, 0, 0, 11, 12, 13];
         firewall.ethdriver_has_data_global_endpoint = "firewall";
+        firewall.notification_pool = 5;
 #endif
 
 #ifndef PASSTHROUGH_SATA


### PR DESCRIPTION
These notifications are used to create mutexes in the Firewall component.  Note that one mutex is required to make allocating mutexes safe.  So there are n-1 mutexes available for use in an app.  See https://github.com/GaloisInc/camkes-tool/pull/1